### PR TITLE
Changed the bundle identifier for DEBUG appending .dev

### DIFF
--- a/DynamicIsland.xcodeproj/project.pbxproj
+++ b/DynamicIsland.xcodeproj/project.pbxproj
@@ -429,7 +429,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = "1.2.1-beta";
-				PRODUCT_BUNDLE_IDENTIFIER = com.Ebullioscopic.Atoll;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Ebullioscopic.Atoll.dev;
 				PRODUCT_NAME = Atoll;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;


### PR DESCRIPTION
## What is the problem?
When both a production and development app are installed on the system MacOS cannot distinguish them since they have the same bundle id so when running Atoll on Xcode the IDE keeps prompting to request permissions.

## What is my contribution?
Changing `Product Bundle Identifier --> Debug` to `com.Ebullioscopic.Atoll.dev` while keeping `Product Bundle Identifier --> Release` the same as before (`com.Ebullioscopic.Atoll`).

## Notes
 When applying these changes it may be useful to reset the permissions related to the bundle id `com.Ebullioscopic.Atoll.dev` by running:
```bash
tccutil reset All com.Ebullioscopic.Atoll
```
Then re-authorizing both versions of the app when MacOS prompts you. The final results in `Privacy & Security --> Accessibility` will display two version of `Atoll.app` if the release and debug versions are both installed (see screenshot)
<img width="835" height="1103" alt="SCR-20251221-japx" src="https://github.com/user-attachments/assets/b93be534-1b09-47b3-b0ed-0b4ead86fbdc" />
