### PR TITLE
Fix timer preset text color

### DIFF
--- a/DynamicIsland/components/Notch/NotchTimerView.swift
+++ b/DynamicIsland/components/Notch/NotchTimerView.swift
@@ -689,6 +689,7 @@ private struct TimerPresetCard: View {
                         .font(.caption.monospaced())
                         .foregroundStyle(.secondary)
                 }
+                .foregroundStyle(preset.color)
 
                 Spacer()
 


### PR DESCRIPTION
Previous:
<img width="640" height="196" alt="image" src="https://github.com/user-attachments/assets/cd37df61-89f8-4aab-9419-33ad667c325e" />

Now:
<img width="640" height="196" alt="image" src="https://github.com/user-attachments/assets/d76daf1c-d71d-4d1c-9a70-03c0c2d22750" />