### PR TITLE
Feature/fixed-custom-focus-identification

### DIFF
--- a/DynamicIsland/managers/DoNotDisturbManager.swift
+++ b/DynamicIsland/managers/DoNotDisturbManager.swift
@@ -131,6 +131,9 @@ final class DoNotDisturbManager: ObservableObject {
 
             if nameChanged {
                 self.currentFocusModeName = finalName
+                    .localizedCaseInsensitiveContains(
+                        "Reduce Interruptions"
+                    ) ? "Reduce Interr." : finalName
             }
 
             if identifierChanged || nameChanged || shouldToggleActive {
@@ -322,7 +325,7 @@ enum FocusModeType: String, CaseIterable {
         case .gaming: return "Gaming"
         case .mindfulness: return "Mindfulness"
         case .reading: return "Reading"
-        case .reduceInterruptions: return "Reduce Interruptions"
+        case .reduceInterruptions: return "Reduce Interr."
         case .custom: return "Focus"
         case .unknown: return "Focus Mode"
         }


### PR DESCRIPTION
## What are the problem?
- Custom focuses are always identified as `FocusModeType.doNotDisturb` instead of `FocusModeType.custom`;
- The "Reduce Interruptions" focus is not recognized;
- There are redundant strings trimmings within `resolve` of `DoNotDisturbManager` since the parameters are already passed to the method trimmed;
- Custom focuses always use a placeholder icon and accent color.
## What is my contribution?
- Fixed identification;
- Added FocusModeType.reduceInterruptions;
- Refactored redundant code in `resolve` of `DoNotDisturbManager`;
- Added `FocusMetadataReader` to get the focus' icon and accent color from the user configurations stored in `~/Library/DoNotDisturb/DB/ModeConfigurations.json` (examples below)
    <img width="478" height="73" alt="before2" src="https://github.com/user-attachments/assets/cb6dbebe-df3f-4109-90b9-ab2ceb2b1af8" />
    <img width="478" height="73" alt="after2" src="https://github.com/user-attachments/assets/cb1301dd-76bd-47b8-8572-43fb02e6f6e8" />
    <br>
    <img width="478" height="73" alt="before1" src="https://github.com/user-attachments/assets/52fd523a-2c4f-4baa-8483-9028707506a2" />
    <img width="478" height="73" alt="after1" src="https://github.com/user-attachments/assets/1ff051d0-9254-4f91-9886-d84b8efcd2a4" />