### PR TITLE
fix: correct shelf item text color in light mode

### DIFF
--- a/DynamicIsland/components/Shelf/Views/ShelfItemView.swift
+++ b/DynamicIsland/components/Shelf/Views/ShelfItemView.swift
@@ -106,7 +106,7 @@ struct ShelfItemView: View {
     private var textView: some View {
         Text(item.displayName)
             .font(.system(size: 12, weight: .medium))
-            .foregroundStyle(.primary)
+            .foregroundStyle(Color.white)
             .lineLimit(2)
             .truncationMode(.middle)
             .multilineTextAlignment(.center)


### PR DESCRIPTION
## Problem
Shelf item labels use `.foregroundStyle(.primary)`, which becomes black in light mode.
Since the shelf background remains dark, the file names are hard to read due to insufficient contrast.

## Solution
Set the text color to `Color.white` to ensure consistent readability against the dark background
in both light and dark system appearances.

## Change
```swift
.foregroundStyle(.primary)
→
.foregroundStyle(Color.white)
```

## Result
### Before (macos Tahoe 26.2 - Light Mode)
<img width="441" height="152" alt="image" src="https://github.com/user-attachments/assets/0a5d59db-e6c6-43a3-8558-9bbb81ab2e1f" />


### After (macos Tahoe 26.2 - Light Mode)
<img width="445" height="155" alt="image" src="https://github.com/user-attachments/assets/6afacc2b-278d-4477-95fd-6fd2d833d44f" />
