### PR TITLE
Fix: Prevent '[]' from displaying when no lyrics are available

### DIFF
--- a/DynamicIsland/managers/MusicManager.swift
+++ b/DynamicIsland/managers/MusicManager.swift
@@ -708,14 +708,27 @@ class MusicManager: ObservableObject {
                 }
             } else {
                 // Fallback: try to decode as UTF8 and handle as LRC or plain text
-                if let lrcString = String(data: data, encoding: .utf8), !lrcString.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                    // If it contains a syncedLyrics key in an object, try that
-                    if let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
-                       let synced = json["syncedLyrics"] as? String {
-                        return parseLRC(synced)
+                if let lrcString = String(data: data, encoding: .utf8) {
+                    let trimmed = lrcString.trimmingCharacters(in: .whitespacesAndNewlines)
+
+                    if trimmed.isEmpty  {
+                        return []
                     }
+
+                    // If it contains a syncedLyrics key in an object, try that
+                    if let json = try? JSONSerialization.jsonObject(with: data, options: []) {
+                        if let dict = json as? [String: Any],
+                            let synced = dict["syncedLyrics"] as? String
+                        {
+                            return parseLRC(synced)
+                        }
+                        if let array = json as? [Any], array.isEmpty {
+                            return []
+                        }
+                    }
+
                     // Otherwise treat as plain lyrics blob
-                    return [LyricLine(timestamp: 0, text: lrcString.trimmingCharacters(in: .whitespacesAndNewlines))]
+                    return [LyricLine(timestamp: 0, text: trimmed)]
                 }
                 return []
             }


### PR DESCRIPTION
### Problem
When the lyrics API returns an empty response, the app shows the literal string "[]" in the lyrics UI.
### Solution
Added a check to detect empty JSON array responses and return an empty array instead of treating "[]" as lyrics text.
### Changes
Added validation in `fetchLyricsFromAPI` to detect "[]" responses
Return empty array when response is "[]" or empty

After fix (no lyrics available):
<img width="619" height="208" alt="Screenshot 2026-01-22 at 3 25 04 AM" src="https://github.com/user-attachments/assets/8a427796-86e5-4dae-84a7-41ce9b3d0d12" />

### Testing
[x] Tested with tracks that have no lyrics
[x] Verified empty state shows correctly
[x] Code builds without errors
Fixes #254 