### PR TITLE
Feat: notes auto save

### DIFF
--- a/DynamicIsland/components/Notch/NotchNotesView.swift
+++ b/DynamicIsland/components/Notch/NotchNotesView.swift
@@ -36,6 +36,7 @@ struct NotchNotesView: View {
     @State private var editorImageData: Data? = nil
     @State private var editorColorIndex: Int = 0
     @State private var editorNoteId: UUID?
+    @State private var autoSaveTask: Task<Void, Never>?
 
     @Default(.enableNotes) var enableNotes
     
@@ -121,6 +122,15 @@ struct NotchNotesView: View {
         }
         .onChange(of: enableNotes) { _, _ in
             updateLayoutState()
+        }
+        .onChange(of: editorContent) { _, _ in
+            scheduleAutoSave()
+        }
+        .onChange(of: editorTitle) { _, _ in
+            scheduleAutoSave()
+        }
+        .onChange(of: editorColorIndex) { _, _ in
+            scheduleAutoSave()
         }
     }
     
@@ -247,6 +257,19 @@ struct NotchNotesView: View {
         savedNotes = notes
     }
 
+    private func scheduleAutoSave() {
+        guard isEditingNewNote || selectedNoteId != nil else { return }
+
+        autoSaveTask?.cancel()
+        autoSaveTask = Task {
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                persistNote()
+            }
+        }
+    }
+
     private func saveNote() {
         persistNote()
         closeEditor()
@@ -338,6 +361,8 @@ struct NotchNotesView: View {
     }
     
     private func closeEditor() {
+        autoSaveTask?.cancel()
+        autoSaveTask = nil
         isEditingNewNote = false
         selectedNoteId = nil
         // Tiny delay to clear state after animation


### PR DESCRIPTION
Closes #315

  ## What

  Notes content is lost when the notch retracts without pressing "Done".
  This PR adds auto-save so changes are always persisted.

  ## Changes

  **Commit 1 — Save on disappear**
  - Extract `persistNote()` from `saveNote()` (persist without closing the editor)
  - Call it from `onDisappear` and `cancelEdit()`
  - Skip empty new notes (no title, no content, no image)

  **Commit 2 — Debounced save while typing**
  - `scheduleAutoSave()` triggers `persistNote()` after 1.5s of inactivity
  - Cancels pending task on each keystroke and when the editor closes