### PR TITLE
feat(media): auto-detect Pear Desktop for seamless YouTube Music sync

### DIFF
--- a/DynamicIsland/managers/MusicManager.swift
+++ b/DynamicIsland/managers/MusicManager.swift
@@ -71,6 +71,10 @@ class MusicManager: ObservableObject {
     // Active controller
     private var activeController: (any MediaControllerProtocol)?
 
+    // Pear Desktop auto-detection
+    private static let pearDesktopBundleID = YouTubeMusicConfiguration.default.bundleIdentifier
+    private var isPearDesktopAutoSwitched: Bool = false
+
     // Published properties for UI
     @Published var songTitle: String = "I'm Handsome"
     @Published var artistName: String = "Me"
@@ -126,9 +130,13 @@ class MusicManager: ObservableObject {
         // Listen for changes to the default controller preference
         NotificationCenter.default.publisher(for: Notification.Name.mediaControllerChanged)
             .sink { [weak self] _ in
+                self?.isPearDesktopAutoSwitched = false
                 self?.setActiveControllerBasedOnPreference()
             }
             .store(in: &cancellables)
+
+        // Observe Pear Desktop launch/terminate for auto-detection
+        setupPearDesktopAutoDetection()
 
         // Initialize deprecation check asynchronously
         Task { @MainActor in
@@ -140,9 +148,53 @@ class MusicManager: ObservableObject {
                 self.isNowPlayingDeprecated = false
             }
             
-            // Initialize the active controller after deprecation check
-            self.setActiveControllerBasedOnPreference()
+            // Check if Pear Desktop is already running at startup
+            let pearDesktopRunning = NSWorkspace.shared.runningApplications.contains {
+                $0.bundleIdentifier == Self.pearDesktopBundleID
+            }
+            
+            if pearDesktopRunning {
+                print("[MusicManager] Pear Desktop detected at startup, auto-switching to YouTubeMusicController")
+                self.isPearDesktopAutoSwitched = true
+                if let controller = self.createController(for: .youtubeMusic) {
+                    self.setActiveController(controller)
+                }
+            } else {
+                // Initialize the active controller after deprecation check
+                self.setActiveControllerBasedOnPreference()
+            }
         }
+    }
+
+    // MARK: - Pear Desktop Auto-Detection
+    private func setupPearDesktopAutoDetection() {
+        NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didLaunchApplicationNotification)
+            .sink { [weak self] notification in
+                guard let self = self,
+                      let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
+                      app.bundleIdentifier == Self.pearDesktopBundleID else { return }
+
+                print("[MusicManager] Pear Desktop launched, auto-switching to YouTubeMusicController")
+                self.isPearDesktopAutoSwitched = true
+                if let controller = self.createController(for: .youtubeMusic) {
+                    self.setActiveController(controller)
+                }
+            }
+            .store(in: &cancellables)
+
+        NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didTerminateApplicationNotification)
+            .sink { [weak self] notification in
+                guard let self = self,
+                      let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
+                      app.bundleIdentifier == Self.pearDesktopBundleID else { return }
+
+                print("[MusicManager] Pear Desktop terminated, reverting to preferred controller")
+                if self.isPearDesktopAutoSwitched {
+                    self.isPearDesktopAutoSwitched = false
+                    self.setActiveControllerBasedOnPreference()
+                }
+            }
+            .store(in: &cancellables)
     }
 
     deinit {


### PR DESCRIPTION
## Summary

When Pear Desktop (YouTube Music desktop app) is running, `MusicManager` now **automatically switches to `YouTubeMusicController`** for seamless media sync — no manual settings change required.

## Problem

Previously, Atoll required users to manually select "YouTube Music" in Settings for the Pear Desktop integration to work. The default controller (`appleMusic` on macOS 15.4+ or `nowPlaying` on older) would never detect Pear Desktop media playback.

## Changes

### `DynamicIsland/managers/MusicManager.swift`

- Added `pearDesktopBundleID` constant (from `YouTubeMusicConfiguration.default`)
- Added `isPearDesktopAutoSwitched` flag to track auto-switch state
- Added `setupPearDesktopAutoDetection()` method that:
  - Observes `NSWorkspace.didLaunchApplicationNotification` → switches to `YouTubeMusicController`
  - Observes `NSWorkspace.didTerminateApplicationNotification` → reverts to user's preferred controller
- Modified `init()` to check if Pear Desktop is already running at startup
- Manual settings changes clear the auto-switch flag (respects user preference)

## Behavior

| Event | Action |
|---|---|
| Pear Desktop already running at Atoll startup | Auto-switch to YouTube Music |
| Pear Desktop launches while Atoll is running | Auto-switch to YouTube Music |
| Pear Desktop terminates | Revert to user's preferred controller |
| User manually changes controller in Settings | Respects manual choice, disables auto-switch |

## Testing

- [x] Build passes (`xcodebuild` exit code 0)
- [x] Verified auto-detection triggers when Pear Desktop is running
- [x] Verified controller reverts on Pear Desktop termination
- [x] Verified manual settings override works correctly
- [x] No new warnings introduced
