### PR TITLE
Fixed Paste Issue in Notes View

### DIFF
--- a/DynamicIsland/components/Notch/NotchNotesView.swift
+++ b/DynamicIsland/components/Notch/NotchNotesView.swift
@@ -158,9 +158,13 @@ struct NotchNotesView: View {
             return
         }
         
-        // Fallback to text if not editing and clipboard has text
-        if !isEditingNewNote && selectedNoteId == nil {
-            if let text = pasteboard.string(forType: .string) {
+        // Handle text paste
+        if let text = pasteboard.string(forType: .string) {
+            if isEditingNewNote || selectedNoteId != nil {
+                // In editor: insert text at the end of content since we intercepted the shortcut
+                editorContent.append(text)
+            } else {
+                // Not in editor: create a new note with the pasted text
                 createNoteWithContent(text)
             }
         }


### PR DESCRIPTION
## Description
This PR fixes a bug with the paste shortcut (`Cmd + V`) in the notes view. Previously, the shortcut only functioned for images; this update enables support for both text and images.

## Changes
- Updated `NotchNotesView.swift` to correctly handle both `.string` and image data from the system pasteboard.
- Added logic to append pasted text to the existing editor content or create a new note if the editor is inactive.
