### PR TITLE
fix(mediacontrollers): apple music artwork for streamed content

### DIFF
--- a/DynamicIsland/MediaControllers/AppleMusicController.swift
+++ b/DynamicIsland/MediaControllers/AppleMusicController.swift
@@ -167,9 +167,6 @@ class AppleMusicController: MediaControllerProtocol {
 
     // MARK: - Private Methods
 
-    /// Searches the Apple Music catalog (via iTunes Search API) for the current
-    /// track and downloads its artwork. This works for streamed content where
-    /// AppleScript cannot access artwork data.
     private func fetchArtworkFromCatalog(title: String, artist: String, album: String) async -> Data? {
         let key = "\(title)|\(artist)|\(album)"
 


### PR DESCRIPTION
When using the Apple Music controller, album artwork fails to display for streamed tracks that have not been added to the user's Library. AppleScript's `raw data of artwork 1 of current track` returns empty data for these tracks.

This change adds a fallback that searches the iTunes Search API using the track's title and artist, then selects the correct result by matching against the album name from the response fields.

- Added iTunes Search API fallback in `AppleMusicController` for artwork retrieval when AppleScript returns empty artwork data
- Search query uses title and artist only to avoid false matches; album is validated against structured response fields to select the correct result
- Artwork is cached per track to avoid redundant network requests
- Simplified the AppleScript by removing the ineffective Library playlist lookup fallback and collapsed the duplicate macOS 26 / pre-26 script branches
- Replaced `JSONSerialization` dictionary access with `Decodable` structs (`ITunesSearchResponse`, `ITunesTrack`) to match codebase conventions