### PR TITLE
Fix terminal keyboard open + sticky outside-click

### DIFF
--- a/DynamicIsland/ContentView.swift
+++ b/DynamicIsland/ContentView.swift
@@ -82,6 +82,7 @@ struct ContentView: View {
     @Default(.showStandardMediaControls) var showStandardMediaControls
     @Default(.externalDisplayStyle) var externalDisplayStyle
     @Default(.hideNonNotchUntilHover) var hideNonNotchUntilHover
+    @Default(.terminalStickyMode) var terminalStickyMode
     
     // Dynamic sizing based on view type and graph count with smooth transitions
     var dynamicNotchSize: CGSize {
@@ -520,6 +521,7 @@ struct ContentView: View {
                             currentView: currentViewString
                         )
                     }
+                    syncStickyTerminalOutsideClickMonitor()
                 }
                 .sensoryFeedback(.alignment, trigger: haptics)
                 .contextMenu {
@@ -546,12 +548,6 @@ struct ContentView: View {
         )
         .frame(maxHeight: .infinity, alignment: .top)
         .environmentObject(privacyManager)
-        .onChange(of: dynamicNotchSize) { oldSize, newSize in
-            guard oldSize != newSize else { return }
-            runAfter(0.1) {
-                vm.shouldRecheckHover.toggle()
-            }
-        }
         .background(dragDetector)
         .environmentObject(vm)
         .environmentObject(webcamManager)
@@ -565,6 +561,9 @@ struct ContentView: View {
             }
             enqueueMusicControlWindowSync(forceRefresh: true)
             startHiddenEdgeHoverPolling()
+        }
+        .onChange(of: terminalStickyMode) { _, _ in
+            syncStickyTerminalOutsideClickMonitor()
         }
         .onChange(of: vm.notchState) { _, state in
             if state == .open {
@@ -1750,6 +1749,16 @@ struct ContentView: View {
             NSEvent.removeMonitor(hoverClickLocalMonitor)
             self.hoverClickLocalMonitor = nil
         }
+    }
+
+    /// Installs the global outside-click monitor when Terminal + sticky mode are active (e.g. keyboard-opened terminal).
+    /// Removes the monitor when the tab, sticky setting, or open state no longer applies.
+    private func syncStickyTerminalOutsideClickMonitor() {
+        guard vm.notchState == .open, terminalStickyMode, coordinator.currentView == .terminal else {
+            removeStickyTerminalClickMonitor()
+            return
+        }
+        installStickyTerminalClickMonitor()
     }
 
     private func installStickyTerminalClickMonitor() {

--- a/DynamicIsland/DynamicIslandApp.swift
+++ b/DynamicIsland/DynamicIslandApp.swift
@@ -1041,12 +1041,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             guard Defaults[.enableShortcuts], Defaults[.enableTerminalFeature] else { return }
 
             if vm.notchState == .closed {
+                closeNotchWorkItem?.cancel()
+                closeNotchWorkItem = nil
                 vm.open()
                 coordinator.currentView = .terminal
             } else {
                 if coordinator.currentView == .terminal {
                     vm.close()
                 } else {
+                    closeNotchWorkItem?.cancel()
+                    closeNotchWorkItem = nil
                     coordinator.currentView = .terminal
                 }
             }


### PR DESCRIPTION
**Root causes**:
- **Snap shut:** `dynamicNotchSize` updates (e.g. switching to Terminal’s tall layout) toggled `shouldRecheckHover`, which ran the “popover-style” path that calls `vm.close()` when the notch is open, not hovering, and auto-close is allowed. Keyboard opens never set `isHovering`, so that path fired right after open.
- **Sticky + outside click:** The global outside-click monitor was only installed from `handleHover(false)` after the pointer had left the notch. Keyboard-only opens never ran that hover lifecycle, so the monitor was often never installed.
- **Timer:** `toggleNotchOpen` schedules a 3s close; `toggleTerminalTab` did not clear it when focusing Terminal.

**Changes:**
- `ContentView.swift`: Removed `onChange(of: dynamicNotchSize)` that toggled `shouldRecheckHover`.
- `ContentView.swift`: Added `syncStickyTerminalOutsideClickMonitor()` and `@Default(.terminalStickyMode)`, call sync from `onChange(of: coordinator.currentView)` and `onChange(of: terminalStickyMode)` so the sticky dismiss monitor is installed whenever Terminal + sticky + open apply, and removed when they don’t.
- `DynamicIslandApp.swift`: In `toggleTerminalTab`, cancel and clear `closeNotchWorkItem` when opening from closed or switching another tab to Terminal.