### PR TITLE
[Bug Fix] Terminal Bug(s)

### DIFF
--- a/DynamicIsland/managers/TerminalManager.swift
+++ b/DynamicIsland/managers/TerminalManager.swift
@@ -218,6 +218,9 @@ class TerminalManager: ObservableObject {
             ?? .blinkBlock
         view.getTerminal().setCursorStyle(cursorStyle.swiftTermStyle)
 
+        // Keep drawing the selected cursor style when TerminalView.hasFocus is false; SwiftTerm
+        view.caretViewTracksFocus = false
+
         // Scrollback
         let scrollback = Defaults[.terminalScrollbackLines]
         view.getTerminal().buffer.changeHistorySize(scrollback)

--- a/DynamicIsland/managers/TerminalManager.swift
+++ b/DynamicIsland/managers/TerminalManager.swift
@@ -216,7 +216,7 @@ class TerminalManager: ObservableObject {
         // Cursor style
         let cursorStyle = TerminalCursorStyleOption(rawValue: Defaults[.terminalCursorStyle])
             ?? .blinkBlock
-        view.getTerminal().options.cursorStyle = cursorStyle.swiftTermStyle
+        view.getTerminal().setCursorStyle(cursorStyle.swiftTermStyle)
 
         // Scrollback
         let scrollback = Defaults[.terminalScrollbackLines]
@@ -254,7 +254,7 @@ class TerminalManager: ObservableObject {
     /// Updates cursor style on the live terminal view.
     func applyCursorStyle(_ style: TerminalCursorStyleOption) {
         guard let view = terminalView else { return }
-        view.getTerminal().options.cursorStyle = style.swiftTermStyle
+        view.getTerminal().setCursorStyle(style.swiftTermStyle)
         view.setNeedsDisplay(view.bounds)
     }
 


### PR DESCRIPTION
Fixes point 3 of issue #371. By using `setCursorStyle` so the delegate updates `CaretView`(`options` alone does not)